### PR TITLE
Make sure the option rssFullText is honored

### DIFF
--- a/layouts/partials/rss/item.html
+++ b/layouts/partials/rss/item.html
@@ -1,0 +1,73 @@
+{{- $params := .Page.Params | merge .Site.Params.Page | merge (dict "author" .Site.Author.name) -}}
+{{- $image := $params.featuredImagePreview | default $params.featuredImage -}}
+{{- with .Page.Resources.GetMatch (printf "%s" ($image)) -}}
+    {{- $image = .RelPermalink -}}
+{{- end -}}
+{{- with .Page.Resources.GetMatch "featured-image" -}}
+    {{- $image = .RelPermalink -}}
+{{- end -}}
+{{- with .Page.Resources.GetMatch "featured-image-preview" -}}
+    {{- $image = .RelPermalink -}}
+{{- end -}}
+<item>
+    <title>
+        {{- .Page.Title -}}
+    </title>
+    <link>
+        {{- .Page.Permalink -}}
+    </link>
+    <pubDate>
+        {{- .Page.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700"  -}}
+    </pubDate>
+    {{- if .Page.Params.authors -}}
+    {{- $lang := ( .Page.Language.Lang | default $.Lang ) -}}
+        {{- range $i, $name := .Page.Params.authors -}}
+            {{- if $.Site.Data.authors -}}
+                {{- with partial "function/author.html" (dict "name" $name "author" (index $.Site.Data.authors $name) "lang" $lang) -}}
+                    <author>
+                        <name>{{- .name -}}</name>
+                        {{- if .absLink -}}
+                            <uri>{{ .absLink | absURL }}</uri>
+                        {{- else -}}
+                            <uri>{{ .link | absURL }}</uri>
+                        {{- end -}}
+                        {{- if .email -}}
+                            <email>{{ .email }}</email>
+                        {{- end -}}
+                    </author>
+                {{- end -}}
+            {{- else -}}
+                <author>
+                    <name>{{- $name -}}</name>
+                </author>
+            {{- end -}}
+        {{- end -}}
+    {{- else -}}
+    <author>
+        <name>{{- $params.author | default (T "author") -}}</name>
+    </author>
+    {{- end -}}
+    <guid>
+        {{- .Page.Permalink -}}
+    </guid>
+    <description>
+        {{- "<![CDATA[" | safeHTML -}}
+        {{- with $image -}}
+            <div class="featured-image">
+                <img src="{{ . }}" referrerpolicy="no-referrer">
+            </div>
+        {{- end -}}
+        {{- $content := .Page.Description -}}
+        {{- if .Site.Params.Page.rssFullText -}}
+            {{- $content = dict "Content" .Page.Content "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" -}}
+        {{- else -}}
+            {{- with .Page.Summary -}}
+                {{- $content = dict "Content" . "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" -}}
+            {{- end -}}
+        {{- end -}}
+        {{/*  {{- $content | replaceRE `<figure[^>]*>.*</figure>` "" | replaceRE `<img[^>]*( /)?>` "" | safeHTML -}}  */}}
+        {{- $content | safeHTML -}}
+        {{- "]]>" | safeHTML -}}
+    </description>
+</item>
+


### PR DESCRIPTION
Override the layouts/partials/rss/item.html provided by the theme with a custom one, to make sure the rssFullText option is honored.